### PR TITLE
Ssh para trustos

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "java:war:prod": "npm run java:war -- -Pprod",
     "prepare": "husky install",
     "prettier:check": "prettier --check \"{,src/**/}*.{md,json,yml,html,java}\"",
-    "prettier:format": "prettier --write \"{,src/**/}*.{md,json,yml,html,java}\""
+    "prettier:format": "prettier --write \"{,src/**/}*.{md,json,yml,html,java}\"",
+    "trustos": "./ssh-trustos.sh"
   },
   "config": {
     "backend_port": "8080",

--- a/ssh-trustos.sh
+++ b/ssh-trustos.sh
@@ -1,0 +1,2 @@
+ssh -fN trustos
+hpts -s 127.0.0.1:5656 -p 5657


### PR DESCRIPTION
Se ha preparado un script, llamado ssh-trustos.sh,
el cual abre un puerto en la maquina remota y asi poder
escucharlo en nuestra maquina local y
lanzar peticiones HTTP a la api de trustOS.

Ademas se ha añadido un script npm , añadido a package.json para poder ejecutarlo más comodamente
desde visual studio code.